### PR TITLE
Remove Event & Validator providers

### DIFF
--- a/src/commands/GenerateHelperCommand.php
+++ b/src/commands/GenerateHelperCommand.php
@@ -68,10 +68,8 @@ EOD;
 		$providers['Auth']      = 'Illuminate\Auth\Guard';
 		$providers['Cache']     = 'Illuminate\Cache\StoreInterface';
 		$providers['DB']        = 'Illuminate\Database\Connection';
-		$providers['Event']     = 'Illuminate\Events\Event';
 		$providers['Queue']     = 'Illuminate\Queue\QueueInterface';
 		$providers['Redis']     = 'Illuminate\Redis\Database';
-		$providers['Validator'] = 'Illuminate\Validation\Validator';
 
 		//this is the main parser
 		//it tries to find a class to reflect, then gets the public properties, gets the public methods


### PR DESCRIPTION
Nice to see you take a similar approach to code completion :)

I don't think the facades returned by Even en Validator are wrong.
When you look at the docs, you see you would expect Validator::make() and Event::fire(), which are defined in the class returned by getFacadeRoot().
